### PR TITLE
Fix the CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Some time in the last year the CI build stopped working. Who knows exactly why, but since the `jmespath-java` repo still seems to work, let's use its setup.