### PR TITLE
Release 0.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>jmespath-contrib</artifactId>
-  <version>0.3.1-SNAPSHOT</version>
+  <version>0.4.1-SNAPSHOT</version>
   <name>JMESPath Contributions</name>
   <description>Community contributed extensions to JMESPath for Java</description>
 

--- a/src/main/java/io/burt/jmespath/contrib/function/MathBiFunction.java
+++ b/src/main/java/io/burt/jmespath/contrib/function/MathBiFunction.java
@@ -34,8 +34,5 @@ public abstract class MathBiFunction extends BaseFunction {
     }
   }
 
-  /**
-   * Subclasses implement this method.
-   */
   protected abstract double performMathOperation(double x, double y);
 }

--- a/src/main/java/io/burt/jmespath/contrib/function/RegularExpressionFunction.java
+++ b/src/main/java/io/burt/jmespath/contrib/function/RegularExpressionFunction.java
@@ -36,9 +36,6 @@ public abstract class RegularExpressionFunction extends SubstringMatchingFunctio
     return runtime.toString(arguments.get(i).value());
   }
 
-  /**
-   * Subclasses may override these methods if parameter positions are different than usual.
-   */
   protected int inputArgumentPosition() {
     return 0;
   }


### PR DESCRIPTION
Release v0.4.0 with #5 

To do this I had to remove a few Javadoc comments because the Maven Javadoc plugin complained about missing `@return` and `@param`. I decided that the comments were redundant and better removed than adding placeholder tags.

The release has been performed, this PR just needs to be approved so that the commits can be added to master.